### PR TITLE
disableExternalRayForces prop

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -155,7 +155,7 @@ EcctrlProps: {
   rayHitForgiveness: 0.1, // Ray hit forgiveness
   rayLength: capsuleRadius + 2, // Ray length
   rayDir: { x: 0, y: -1, z: 0 }, // Ray direction
-  disableRay: false, // Disable Ray hits
+  disableExternalRayForces: false, // Disable applied ray hit forces 
   floatingDis: capsuleRadius + floatHeight, // Floating distance
   springK: 1.2, // Spring constant
   dampingC: 0.08, // Damping coefficient

--- a/readme.md
+++ b/readme.md
@@ -155,6 +155,7 @@ EcctrlProps: {
   rayHitForgiveness: 0.1, // Ray hit forgiveness
   rayLength: capsuleRadius + 2, // Ray length
   rayDir: { x: 0, y: -1, z: 0 }, // Ray direction
+  disableRay: false, // Disable Ray hits
   floatingDis: capsuleRadius + floatHeight, // Floating distance
   springK: 1.2, // Spring constant
   dampingC: 0.08, // Damping coefficient

--- a/readme.md
+++ b/readme.md
@@ -155,7 +155,7 @@ EcctrlProps: {
   rayHitForgiveness: 0.1, // Ray hit forgiveness
   rayLength: capsuleRadius + 2, // Ray length
   rayDir: { x: 0, y: -1, z: 0 }, // Ray direction
-  disableExternalRayForces: false, // Disable applied ray hit forces 
+  disableExternalRayForces: false, // Disable ray hit forces to external objects
   floatingDis: capsuleRadius + floatHeight, // Floating distance
   springK: 1.2, // Spring constant
   dampingC: 0.08, // Damping coefficient

--- a/src/Ecctrl.tsx
+++ b/src/Ecctrl.tsx
@@ -92,7 +92,7 @@ const Ecctrl: ForwardRefRenderFunction<RapierRigidBody, EcctrlProps> = ({
   rayHitForgiveness = 0.1,
   rayLength = capsuleRadius + 2,
   rayDir = { x: 0, y: -1, z: 0 },
-  disableRay = false,
+  disableExternalRayForces = false,
   floatingDis = capsuleRadius + floatHeight,
   springK = 1.2,
   dampingC = 0.08,
@@ -1054,7 +1054,7 @@ const Ecctrl: ForwardRefRenderFunction<RapierRigidBody, EcctrlProps> = ({
       );
 
       // Apply jump force downward to the standing platform
-      if (!disableRay) {
+      if (!disableExternalRayForces) {
         characterMassForce.y *= jumpForceToGroundMult;
         rayHit.collider
           .parent()
@@ -1280,13 +1280,13 @@ const Ecctrl: ForwardRefRenderFunction<RapierRigidBody, EcctrlProps> = ({
         false
       );
 
-      // Apply opposite force to standing object (gravity g in rapier is 0.11 ?_?)
       characterMassForce.set(0, floatingForce > 0 ? -floatingForce : 0, 0);
 
-      if (!disableRay) {
+      // Apply opposite force to standing object (gravity g in rapier is 0.11 ?_?)
+      if (!disableExternalRayForces) {
         rayHit.collider
-        .parent()
-        ?.applyImpulseAtPoint(characterMassForce, standingForcePoint, true);
+          .parent()
+          ?.applyImpulseAtPoint(characterMassForce, standingForcePoint, true);
       }
     }
 
@@ -1485,7 +1485,7 @@ export interface EcctrlProps extends RigidBodyProps {
   rayHitForgiveness?: number;
   rayLength?: number;
   rayDir?: { x: number; y: number; z: number };
-  disableRay?: boolean;
+  disableExternalRayForces?: boolean;
   floatingDis?: number;
   springK?: number;
   dampingC?: number;

--- a/src/Ecctrl.tsx
+++ b/src/Ecctrl.tsx
@@ -1131,7 +1131,7 @@ const Ecctrl: ForwardRefRenderFunction<RapierRigidBody, EcctrlProps> = ({
     /**
      * Ray detect if on rigid body or dynamic platform, then apply the linear velocity and angular velocity to character
      */
-    if (rayHit && canJump && !disableRay) {
+    if (rayHit && canJump) {
       if (rayHit.collider.parent()) {
         // Getting the standing force apply point
         standingForcePoint.set(

--- a/src/Ecctrl.tsx
+++ b/src/Ecctrl.tsx
@@ -1053,9 +1053,10 @@ const Ecctrl: ForwardRefRenderFunction<RapierRigidBody, EcctrlProps> = ({
         true
       );
 
+      characterMassForce.y *= jumpForceToGroundMult;
+
       // Apply jump force downward to the standing platform
       if (!disableExternalRayForces) {
-        characterMassForce.y *= jumpForceToGroundMult;
         rayHit.collider
           .parent()
           ?.applyImpulseAtPoint(characterMassForce, standingForcePoint, true);

--- a/src/Ecctrl.tsx
+++ b/src/Ecctrl.tsx
@@ -1271,7 +1271,7 @@ const Ecctrl: ForwardRefRenderFunction<RapierRigidBody, EcctrlProps> = ({
     /**
      * Apply floating force
      */
-    if (!disableRay && rayHit != null && canJump && rayHit.collider.parent()) {
+    if (rayHit != null && canJump && rayHit.collider.parent()) {
       floatingForce =
         springK * (floatingDis - rayHit.toi) -
         characterRef.current.linvel().y * dampingC;
@@ -1282,9 +1282,12 @@ const Ecctrl: ForwardRefRenderFunction<RapierRigidBody, EcctrlProps> = ({
 
       // Apply opposite force to standing object (gravity g in rapier is 0.11 ?_?)
       characterMassForce.set(0, floatingForce > 0 ? -floatingForce : 0, 0);
-      rayHit.collider
+
+      if (!disableRay) {
+        rayHit.collider
         .parent()
         ?.applyImpulseAtPoint(characterMassForce, standingForcePoint, true);
+      }
     }
 
     /**


### PR DESCRIPTION
I was getting nasty errors like: 
```
Uncaught RuntimeError: unreachable
    at 0057ee2e:0x11eb73
    at 0057ee2e:0x14b636
    at 0057ee2e:0x145389
    at 0057ee2e:0x1104bf
    at AA.rbApplyImpulseAtPoint (rapier_wasm3d.js:4555:14)
    at lA.applyImpulseAtPoint (rigid_body.ts:843:21)
    at Object.current (Ecctrl.tsx:1058:11)
    at render$1 (index-d98fd1c7.esm.js:1542:22)
    at loop (index-d98fd1c7.esm.js:1571:19)
 ```
It is a race condition if jump / move + update Floor / platform physics too quickly.

I have a static floor, that updates frequently, but I do not need the character to apply forces to the floor.
In this case, ecctrl can safely remove all rayHits to the floor / platform.

Fixes the Rust crashing errors, still works as a character controller great, and general performance is also improved since bypassing much physics forces.

Downside is platforms / floors, IF dynamic, they would not get the cool: "trampoline bounce effect" like in ecctrl demo. However there is many apps that have fixed terrain / floors / platforms which rayHits become mostly bloat, so a prop `disableExternalRayForces` introduced so devs can configure how they prefer.