### PR TITLE
feat: bump @react-three/rapier from 1.3.1 to 1.4.0

### DIFF
--- a/example/FloatingPlatform.tsx
+++ b/example/FloatingPlatform.tsx
@@ -1,6 +1,5 @@
 import {
   CuboidCollider,
-  RapierRigidBody,
   RigidBody,
   useRapier,
 } from "@react-three/rapier";
@@ -8,7 +7,7 @@ import { useEffect, useRef, useMemo } from "react";
 import * as THREE from "three";
 import { useFrame } from "@react-three/fiber";
 import { Text } from "@react-three/drei";
-import type { RayColliderToi } from "@dimforge/rapier3d-compat";
+import type { RayColliderHit } from "@dimforge/rapier3d-compat";
 
 export default function FloatingPlatform() {
   // Preset
@@ -27,7 +26,7 @@ export default function FloatingPlatform() {
   const springDirVec = useMemo(() => new THREE.Vector3(), []);
   const origin = useMemo(() => new THREE.Vector3(), []);
   const rayCast = new rapier.Ray(origin, rayDir);
-  let rayHit: RayColliderToi = null;
+  let rayHit: RayColliderHit | null = null;
   const floatingDis = 0.8;
   const springK = 2.5;
   const dampingC = 0.15;
@@ -35,14 +34,14 @@ export default function FloatingPlatform() {
   const springDirVec2 = useMemo(() => new THREE.Vector3(), []);
   const origin2 = useMemo(() => new THREE.Vector3(), []);
   const rayCast2 = new rapier.Ray(origin2, rayDir);
-  let rayHit2: RayColliderToi = null;
+  let rayHit2: RayColliderHit | null = null;
   // Moving Platform
   const springDirVecMove = useMemo(() => new THREE.Vector3(), []);
   const originMove = useMemo(() => new THREE.Vector3(), []);
   const rayCastMove = new rapier.Ray(originMove, rayDir);
   const movingVel = useMemo(() => new THREE.Vector3(), []);
   let movingDir = 1;
-  let rayHitMove: RayColliderToi = null;
+  let rayHitMove: RayColliderHit | null = null;
 
   useEffect(() => {
     // Loack platform 1 rotation
@@ -74,8 +73,8 @@ export default function FloatingPlatform() {
         rayCast,
         rayLength,
         false,
-        null,
-        null,
+        undefined,
+        undefined,
         floatingPlateRef.current,
         floatingPlateRef.current
       );
@@ -91,8 +90,8 @@ export default function FloatingPlatform() {
         rayCast2,
         rayLength,
         false,
-        null,
-        null,
+        undefined,
+        undefined,
         floatingPlateRef2.current,
         floatingPlateRef2.current
       );
@@ -108,8 +107,8 @@ export default function FloatingPlatform() {
         rayCastMove,
         rayLength,
         false,
-        null,
-        null,
+        undefined,
+        undefined,
         floatingMovingPlateRef.current,
         floatingMovingPlateRef.current
       );
@@ -138,7 +137,7 @@ export default function FloatingPlatform() {
     if (rayHit) {
       if (rayHit.collider.parent()) {
         const floatingForce =
-          springK * (floatingDis - rayHit.toi) -
+          springK * (floatingDis - rayHit.timeOfImpact) -
           floatingPlateRef.current.linvel().y * dampingC;
         floatingPlateRef.current.applyImpulse(
           springDirVec.set(0, floatingForce, 0),
@@ -151,7 +150,7 @@ export default function FloatingPlatform() {
     if (rayHit2) {
       if (rayHit2.collider.parent()) {
         const floatingForce2 =
-          springK * (floatingDis - rayHit2.toi) -
+          springK * (floatingDis - rayHit2.timeOfImpact) -
           floatingPlateRef2.current.linvel().y * dampingC;
         floatingPlateRef2.current.applyImpulse(
           springDirVec2.set(0, floatingForce2, 0),
@@ -164,7 +163,7 @@ export default function FloatingPlatform() {
     if (rayHitMove) {
       if (rayHitMove.collider.parent()) {
         const floatingForceMove =
-          springK * (floatingDis - rayHitMove.toi) -
+          springK * (floatingDis - rayHitMove.timeOfImpact) -
           floatingMovingPlateRef.current.linvel().y * dampingC;
         floatingMovingPlateRef.current.applyImpulse(
           springDirVecMove.set(0, floatingForceMove, 0),

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
       "peerDependencies": {
         "@react-three/drei": ">=9.0",
         "@react-three/fiber": ">=8.0",
-        "@react-three/rapier": ">=1.0",
+        "@react-three/rapier": ">=1.4.0",
         "react": ">=18",
         "react-dom": ">=18.0",
         "three": ">=0.153"
@@ -417,9 +417,9 @@
       "peer": true
     },
     "node_modules/@dimforge/rapier3d-compat": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.11.2.tgz",
-      "integrity": "sha512-vdWmlkpS3G8nGAzLuK7GYTpNdrkn/0NKCe0l1Jqxc7ZZOB3N0q9uG/Ap9l9bothWuAvxscIt0U97GVLr0lXWLg==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.13.1.tgz",
+      "integrity": "sha512-SsQ/MTH4Vvs8f62g31iVV1VOmzwNwsJl91rVzafi5B2mCrI2OsQ3VyjJOb4/tvS5VNc6OLjIDgfClcOAkW+O2A==",
       "peer": true
     },
     "node_modules/@esbuild/android-arm": {
@@ -1530,14 +1530,14 @@
       }
     },
     "node_modules/@react-three/rapier": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@react-three/rapier/-/rapier-1.1.1.tgz",
-      "integrity": "sha512-DlMHJRIErr9753C4CO3V06rgrP4b5/LyDnwzeNOCPrWgasILbkjYIe37RcQ+MZN2n6YpmQNSFD3WpnU9XD/QxA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@react-three/rapier/-/rapier-1.4.0.tgz",
+      "integrity": "sha512-mQryvEx9mW6u0bHo3KDc7G6gURjKSOA1I+W9EVNDJmI8hC+HoS9WyDzc8QnXyMYmvUAMEqOQImECNXAtoLacHw==",
       "peer": true,
       "dependencies": {
-        "@dimforge/rapier3d-compat": "0.11.2",
-        "three-stdlib": "2.23.9",
-        "use-asset": "1.0.4"
+        "@dimforge/rapier3d-compat": "0.13.1",
+        "suspend-react": "^0.1.3",
+        "three-stdlib": "2.23.9"
       },
       "peerDependencies": {
         "@react-three/fiber": ">=8.9.0",
@@ -2100,12 +2100,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/fast-deep-equal": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "peer": true
     },
     "node_modules/fflate": {
       "version": "0.6.10",
@@ -3003,18 +2997,6 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
-      }
-    },
-    "node_modules/use-asset": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/use-asset/-/use-asset-1.0.4.tgz",
-      "integrity": "sha512-7/hqDrWa0iMnCoET9W1T07EmD4Eg/Wmoj/X8TGBc++ECRK4m5yTsjP4O6s0yagbxfqIOuUkIxe2/sA+VR2GxZA==",
-      "peer": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3"
-      },
-      "peerDependencies": {
-        "react": ">=17.0"
       }
     },
     "node_modules/use-sync-external-store": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "peerDependencies": {
     "@react-three/drei": ">=9.0",
     "@react-three/fiber": ">=8.0",
-    "@react-three/rapier": ">=1.0",
+    "@react-three/rapier": ">=1.4.0",
     "react": ">=18",
     "react-dom": ">=18.0",
     "three": ">=0.153"

--- a/src/Ecctrl.tsx
+++ b/src/Ecctrl.tsx
@@ -17,7 +17,7 @@ import { useGame } from "./stores/useGame";
 import { useJoystickControls } from "./stores/useJoystickControls";
 import type {
   Collider,
-  RayColliderToi,
+  RayColliderHit,
   Vector,
 } from "@dimforge/rapier3d-compat";
 import React from "react";
@@ -569,7 +569,7 @@ const Ecctrl: ForwardRefRenderFunction<RapierRigidBody, EcctrlProps> = ({
   const characterMassForce: THREE.Vector3 = useMemo(() => new THREE.Vector3(), []);
   const rayOrigin: THREE.Vector3 = useMemo(() => new THREE.Vector3(), []);
   const rayCast = new rapier.Ray(rayOrigin, rayDir);
-  let rayHit: RayColliderToi = null;
+  let rayHit: RayColliderHit | null = null;
 
   /**Test shape ray */
   // const shape = new rapier.Capsule(0.2,0.1)
@@ -585,7 +585,7 @@ const Ecctrl: ForwardRefRenderFunction<RapierRigidBody, EcctrlProps> = ({
   const slopeRayOriginRef = useRef<THREE.Mesh>();
   const slopeRayorigin: THREE.Vector3 = useMemo(() => new THREE.Vector3(), []);
   const slopeRayCast = new rapier.Ray(slopeRayorigin, slopeRayDir);
-  let slopeRayHit: RayColliderToi = null;
+  let slopeRayHit: RayColliderHit | null = null;
 
   /**
    * Point to move setup
@@ -1127,7 +1127,7 @@ const Ecctrl: ForwardRefRenderFunction<RapierRigidBody, EcctrlProps> = ({
     //   characterRef.current
     // );
 
-    if (rayHit && rayHit.toi < floatingDis + rayHitForgiveness) {
+    if (rayHit && rayHit.timeOfImpact < floatingDis + rayHitForgiveness) {
       if (slopeRayHit && actualSlopeAngle < slopeMaxAngle) {
         canJump = true;
       }
@@ -1143,7 +1143,7 @@ const Ecctrl: ForwardRefRenderFunction<RapierRigidBody, EcctrlProps> = ({
         // Getting the standing force apply point
         standingForcePoint.set(
           rayOrigin.x,
-          rayOrigin.y - rayHit.toi,
+          rayOrigin.y - rayHit.timeOfImpact,
           rayOrigin.z
         );
         const rayHitObjectBodyType = rayHit.collider.parent().bodyType();
@@ -1260,12 +1260,12 @@ const Ecctrl: ForwardRefRenderFunction<RapierRigidBody, EcctrlProps> = ({
         actualSlopeAngle = actualSlopeNormalVec?.angleTo(floorNormal);
       }
     }
-    if (slopeRayHit && rayHit && slopeRayHit.toi < floatingDis + 0.5) {
+    if (slopeRayHit && rayHit && slopeRayHit.timeOfImpact < floatingDis + 0.5) {
       if (canJump) {
         // Round the slope angle to 2 decimal places
         slopeAngle = Number(
           Math.atan(
-            (rayHit.toi - slopeRayHit.toi) / slopeRayOriginOffest
+            (rayHit.timeOfImpact - slopeRayHit.timeOfImpact) / slopeRayOriginOffest
           ).toFixed(2)
         );
       } else {
@@ -1281,7 +1281,7 @@ const Ecctrl: ForwardRefRenderFunction<RapierRigidBody, EcctrlProps> = ({
     if (rayHit != null) {
       if (canJump && rayHit.collider.parent()) {
         floatingForce =
-          springK * (floatingDis - rayHit.toi) -
+          springK * (floatingDis - rayHit.timeOfImpact) -
           characterRef.current.linvel().y * dampingC;
         characterRef.current.applyImpulse(
           springDirVec.set(0, floatingForce, 0),


### PR DESCRIPTION
- Bump @react-three/rapier from v1.3.1 to v1.4.0, which now uses @dimforge/rapier3d-compat 0.13.1
- Update usage of @dimforge/rapier3d-compat per changes from 0.12.0 to 0.13.1
- Change @react-three/rapier peer dependency version from `>=1.0` to `>=1.4.0`
- See: https://github.com/pmndrs/react-three-rapier/blob/main/packages/react-three-rapier/CHANGELOG.md#140