### PR TITLE
Add child event listeners in useFollowCam hook

### DIFF
--- a/src/hooks/useFollowCam.tsx
+++ b/src/hooks/useFollowCam.tsx
@@ -1,6 +1,6 @@
 import { useThree } from "@react-three/fiber";
 // import { useRapier } from "@react-three/rapier";
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import * as THREE from "three";
 import type { camListenerTargetType } from "../Ecctrl";
 
@@ -10,6 +10,7 @@ export const useFollowCam = function (props: UseFollowCamProps) {
   const disableFollowCamPos = props.disableFollowCamPos;
   const disableFollowCamTarget = props.disableFollowCamTarget;
   // const { rapier, world } = useRapier();
+	const [render, setRender] = useState(false);
 
   let isMouseDown = false;
   let previousTouch1: Touch = null;
@@ -292,6 +293,23 @@ export const useFollowCam = function (props: UseFollowCamProps) {
       // followCam.remove(camera);
     };
   });
+
+  useEffect(() => {
+		function onChildAdded() {
+			setRender((prev) => !prev);
+		}
+		function onChildRemoved() {
+			setRender((prev) => !prev);
+		}
+
+		scene.addEventListener("childadded", onChildAdded);
+		scene.addEventListener("childremoved", onChildRemoved);
+
+		return () => {
+			scene.removeEventListener("childadded", onChildAdded);
+			scene.removeEventListener("childremoved", onChildRemoved);
+		};
+	}, [scene]);
 
   return { pivot, followCam, cameraCollisionDetect, joystickCamMove };
 };


### PR DESCRIPTION
This pull request adds child event listeners in the `useFollowCam` hook. The `useFollowCam` hook now listens for "childadded" and "childremoved" events in the scene. When a child is added or removed, the `render` state is updated, triggering a re-render. This ensures that the intersectObjects array is updated correctly when children are added or removed.

closes #117